### PR TITLE
adds deployment artifatcts in Gitlab-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ ops/
 Run the script `setup` in the directory which should be prepared and the
 necessary files are copied from the directory `skel/`.
 
+Then you must change the files according to your needs. In some files "HINT"'s
+are placed to add alternate configuration for different setups. E.g. Gitlab
+Runner in Docker or as process. Do a `fgrep -R HINT` to find them all.
+
 ## Contributing
 
 New ideas, patches and improvements are always welcome. Please do it the usual

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ops/
 Run the script `setup` in the directory which should be prepared and the
 necessary files are copied from the directory `skel/`.
 
-Then you must change the files according to your needs. In some files "HINT"'s
+Then you must change the files according to your needs. In some files "HINT"s
 are placed to add alternate configuration for different setups. E.g. Gitlab
 Runner in Docker or as process. Do a `fgrep -R HINT` to find them all.
 

--- a/skel/.gitlab-ci.yml
+++ b/skel/.gitlab-ci.yml
@@ -1,13 +1,18 @@
 image: 7val/gitlab-job
 
-# Make sure we can start Docker
-services:
-  - docker:dind
+##### HINT!!! If you're runner is not a Docker runner uncomment the following
+#####         configuration.
 
-# When using dind, it's wise to use the overlayfs driver for
-# improved performance.
-variables:
-  DOCKER_DRIVER: overlay2
+## Make sure we can start Docker
+#services:
+#  - docker:dind
+#
+## When using dind, it's wise to use the overlayfs driver for
+## improved performance.
+#variables:
+#  DOCKER_DRIVER: overlay2
+
+##### END HINT
 
 stages:
   - build
@@ -29,3 +34,8 @@ deploy:
   only:
     refs:
       - master
+  # only deploy with human intervention
+  #when: manual
+  artifacts:  # Deployment configuration is saved here
+    paths:
+      - ./artifacts

--- a/skel/Makefile
+++ b/skel/Makefile
@@ -41,7 +41,10 @@ push: ## Push image
 
 deploy: ## Deploy application
 	# Build deploy
-	@docker-compose \
+# HINT!!! Only necessary when your Gitlab Runner is a Docker container.
+	@GITLAB_RUNNER_ID="$(shell docker ps -q -f "label=com.gitlab.gitlab-runner.job.id=$(CI_JOB_ID)" --format '{{.Names}}' )" \
+		docker-compose \
+		-p {{ PROJECT_NAME }}-deploy-$(VERSION)_$(CI_PIPELINE_ID) \
 		-f ops/docker-compose.ops.yml \
 		build \
 		--force-rm \
@@ -49,6 +52,8 @@ deploy: ## Deploy application
 		--pull \
 		deploy-$(ENVIRONMENT)
 	# Run deploy
-	@ops/trap_command.sh \
-		"docker-compose -f ops/docker-compose.ops.yml run -T --rm -e VERSION=$(VERSION) deploy-$(ENVIRONMENT)" \
-		"docker-compose -f ops/docker-compose.ops.yml down -v --remophe-orphans"
+# HINT!!! Only necessary when your Gitlab Runner is a Docker container.
+	@GITLAB_RUNNER_ID="$(shell docker ps -q -f "label=com.gitlab.gitlab-runner.job.id=$(CI_JOB_ID)" --format '{{.Names}}' )" \
+		ops/trap_command.sh \
+		"docker-compose -p {{ PROJECT_NAME }}-deploy-$(VERSION)_$(CI_PIPELINE_ID) -f ops/docker-compose.ops.yml run -T --rm -e VERSION=$(VERSION) deploy-$(ENVIRONMENT)" \
+		"docker-compose -p {{ PROJECT_NAME }}-deploy-$(VERSION)_$(CI_PIPELINE_ID) -f ops/docker-compose.ops.yml down -v --remophe-orphans"

--- a/skel/ops/docker-compose.ops.yml
+++ b/skel/ops/docker-compose.ops.yml
@@ -13,7 +13,7 @@ services:
       - SLOPPY_DEPLOYMENT_TRACE  # activate tracing of the deployment script
       - ENVIRONMENT=development
       - SLOPPY_SAVE_OUTPUT_DIR=${CI_PROJECT_DIR}/artifacts
-    # mount volumes from Gitlab Runner cotainer to save environment
+    # mount volumes from Gitlab Runner container to save environment
     # configuration as artifact.
     volumes_from:
       - container:${GITLAB_RUNNER_ID}

--- a/skel/ops/docker-compose.ops.yml
+++ b/skel/ops/docker-compose.ops.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
 
   deploy-development:
@@ -9,5 +9,15 @@ services:
       - environments/development/myapp.env
     environment:
       - SLOPPY_APITOKEN
-      - DRY_RUN
+      - DRY_RUN  # Do nothing but print out the configuration.
+      - SLOPPY_DEPLOYMENT_TRACE  # activate tracing of the deployment script
       - ENVIRONMENT=development
+      - SLOPPY_SAVE_OUTPUT_DIR=${CI_PROJECT_DIR}/artifacts
+    # mount volumes from Gitlab Runner cotainer to save environment
+    # configuration as artifact.
+    volumes_from:
+      - container:${GITLAB_RUNNER_ID}
+# HINT!!! If your Runner is a standalone process (not running in Docker) comment
+# out above "volumes_from" directive and uncomment the following two lines.
+#    volumes:
+#      - ${CI_PROJECT_DIR}:${CI_PROJECT_DIR}


### PR DESCRIPTION
This commits adds code to save the configuration of the environment as
a Gitlab-Ci artifact.

README.md:
* adds text explaining how to adapt the setup to customer needs

skel/.gitlab-ci.yml:
* comments out code for DIND and overlay which is only necessary when
using a Runner as a process
* adds saving deployment artifacts

skel/Makefile:
* adds GITLAB_RUNNER_ID for saving deployment artifacts when the Runner
is a Docker container

skel/ops/docker-compose.ops.yml:
* bumps version to 2.4
* adds some explaining comments
* adds var SLOPPY_DEPLOYMENT_TRACE
* adds configuration for saving deployment artifacts
* adds usage of unique project name for docker-compose commands